### PR TITLE
Add Zenodo to host pretrained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ You can further help the user understand and contextualize your results by linki
 
 ### Hosting pretrained models files
 
-1. [GitHub Releases](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) - versioning, 2GB file limit, free bandwidth
-2. [Google Drive](https://drive.google.com) - versioning, 15GB, free bandwidth
-3. [Dropbox](https://dropbox.com) - versioning, 2GB (paid unlimited), free bandwidth
-4. [AWS S3](https://aws.amazon.com/s3/) - versioning, paid only, paid bandwidth
+1. [Zenodo](https://zenodo.org) - versioning, 50GB, free bandwidth, DOI, provides long-term preservation
+2. [GitHub Releases](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) - versioning, 2GB file limit, free bandwidth
+3. [Google Drive](https://drive.google.com) - versioning, 15GB, free bandwidth
+4. [Dropbox](https://dropbox.com) - versioning, 2GB (paid unlimited), free bandwidth
+5. [AWS S3](https://aws.amazon.com/s3/) - versioning, paid only, paid bandwidth
  
 ### Managing model files
 


### PR DESCRIPTION
Zenodo offers several benefits compared to the other options detailed in this list. 

* More free storage
* citable DOI
* long-term storage, without ability to delete files

Especially the last point is very important to allow other researchers to reproduce results even years after the release. Therefore I suggest to make zenodo the #1 recommendation for this list.
