### PR TITLE
Add: huggingface_hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can further help the user understand and contextualize your results by linki
 4. [Google Drive](https://drive.google.com) - versioning, 15GB, free bandwidth
 5. [Dropbox](https://dropbox.com) - versioning, 2GB (paid unlimited), free bandwidth
 6. [AWS S3](https://aws.amazon.com/s3/) - versioning, paid only, paid bandwidth
+7. [huggingface_hub](https://github.com/huggingface/huggingface_hub) - versioning, no size limitations, free bandwidth
  
 ### Managing model files
 


### PR DESCRIPTION
Hi @rstojnic,

I have added [huggingface_hub](https://github.com/huggingface/huggingface_hub) to the `Hosting pretrained model files` section. They provide unlimited storage and bandwidth for open-source projects and are built on `git-lfs`.